### PR TITLE
Fix markdown typo in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Navigate to [PATH].
 - For Debian and RHEL based Linux systems, you can install Docker by following these steps:
 
 `$ curl -fsSL https://get.docker.com/ | sh`
+
 `$ sudo systemctl start docker`
 
 Verify that it's running:


### PR DESCRIPTION
I forgot a space between two of commands listed in the README. They're rendered on one line, instead of two, since I used single back ticks. This fixes the formatting error.