### PR TITLE
Fix link to crispr.deniclab.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ __Manuscript authors__: Christopher J. Shoemaker, Tina Q. Huang, Nicholas R. Wei
 __Shiny app authors__: Nicholas R. Weir and Christopher J. Shoemaker
 
 ## To access web-hosted version of this app:
-Navigate to [crispr.deniclab.com](crispr.deniclab.com).
+Navigate to [crispr.deniclab.com](http://crispr.deniclab.com).
 
 ## To run the app locally on your computer:
 - Install [RStudio](www.rstudio.com)


### PR DESCRIPTION
The link in the README to crispr.deniclab.com actually points to:

https://github.com/deniclab/denic-shiny-crispr/blob/master/crispr.deniclab.com

Prefacing the Markdown link with "http://" fixes this. I will switch this to "https://" when Let's Encrypt is set up.